### PR TITLE
add fallback method for route

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -132,7 +132,12 @@ class App
 
             $controller_and_action = static::parseControllerAction($path);
             if (!$controller_and_action) {
-                static::send404($connection, $request);
+                // when route, controller and action not found, try to use Route::fallback
+                if (($fallback = Route::getFallback()) !== null) {
+                    static::send($connection, $fallback($request), $request);
+                } else {
+                    static::send404($connection, $request);
+                }
                 return null;
             }
             $app = $controller_and_action['app'];

--- a/src/Route.php
+++ b/src/Route.php
@@ -37,6 +37,10 @@ class Route
      */
     protected static $_hasRoute = false;
 
+    /**
+     * @var null|callable
+     */
+    protected static $_fallback = null;
 
     /**
      * @param $path
@@ -160,5 +164,21 @@ class Route
     public static function setCollector($route)
     {
         static::$_collector = $route;
+    }
+
+    /**
+     * @param callable $callback
+     */
+    public static function fallback(callable $callback) {
+        if (is_callable($callback)) {
+            static::$_fallback = $callback;
+        }
+    }
+
+    /**
+     * @return callable|null
+     */
+    public static function getFallback() {
+        return is_callable(static::$_fallback) ? static::$_fallback : null;
     }
 }


### PR DESCRIPTION
Add a new method ''fallback'' for Route.

This can define a handle function when route, controller and action can not dispatch.

You can define route fallback as follow:

`Route::fallback(function(\support\Request $request) {
    return json(['status' => false]);
});`

Then when you visit a not defined route, you can get this response:

`{"status":false}`

If you havn't defined a route fallback, the system will default response like this:

`<h3>404 Not Found</h3>`