### PR TITLE
修复因路由解析组装控制器时，类名可能为小写模式，导致的重复创建类实例，同一控制器被创建两个实例的问题（容器启动时是使用大写类名来注册实例的）

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -23,6 +23,7 @@ class Container implements ContainerInterface
      */
     public function get($name)
     {
+        $name = strtolower($name);
         if (!isset($this->_instances[$name])) {
             if (!class_exists($name)) {
                 throw new NotFoundException("Class '$name' not found");


### PR DESCRIPTION
应用启动时，注入容器的实例皆使用 `className` 作为索引名。在后续通过解析请求路由得到控制器名称时，再次通过容器获取对应实例时，会存在键名大小写的影响，主要问题出现在应用中间件的代码块。

例如 `/index/index` 请求，在 `\Webman\App::onMessage::158` 通过 `\Webman\App::parseControllerAction::418` 解析后的 `controller` 类名为 `app\controller\index`，因 `php` 对类名大小写不敏感，所以使用容器` \Webman\Container::get($name)` 判断 `class_exists($name)` 时不会报错，但应用启动时 `\Webman\Container `中注册的 `app\controller\Index::class` 的实例名是 `app\controller\Index` 而非 `app\controller\index`，故会再创建一个实例对象出来。

而 `Webman\Http\Request::$controller` 经过对实例对象的 `get_class()` 操作转为了标准的`大写类名`，造成了中间件中 `callback $next` 中的控制器实例（通过 `app\controller\index` 获取的），同应用代码中使用 `\support\bootstrap\Container::get($reqeust->controller)` 的实例（通过 `app\controller\Index` 获取的）实例对象不一致。当然，如果是 `/Index/index` 就不会触发这个问题。考虑到控制器可能为` FooBarDelta` 的场景，所以建议在容器入口做统一转为小写。

```php
// framework \Webman\App::onMessage 158
$controller_and_action = static::parseControllerAction($path);
```
```php
// framework \Webman\App::parseControllerAction::418
if ($path && $path[0] === '/') {
    $path = \substr($path, 1);
}
$explode = \explode('/', $path);
$action = 'index';

// 这里通过路由得到的 controller symbol 可能是小写的 index 根据用户的请求路径决定 
// 我很少用 /Index/index url路径 来访问 IndexController::index 的
$controller = $explode[0];
if ($controller === '') {
    return false;
}
if (!empty($explode[1])) {
    $action = $explode[1];
}
// 这里可能是 "app\\controller\\index" 这样就无法获取容器中已注册的 "app\\controller\\Index" 实例
$controller_class = "app\\controller\\$controller";
if (static::loadController($controller_class) && \is_callable([$instance = static::$_container->get($controller_class), $action])) {
    return [
        'app'        => '',
        'controller' => \get_class($instance),
        'action'     => static::getRealMethod($controller_class, $action),
        'instance'   => $instance,
    ];
}
```
```php
// framework \Webman\App::getCallback
array_reduce($middleware, function ($carry, $pipe) {
    return function ($request) use ($carry, $pipe) {
        return $pipe($request, $carry);
    };
}, function ($request) use ($call, $args) {//reduce 中间件时 $call 很可能是使用控制器名小写来创建的实例
    try {
        if ($args === null) {
            $response = $call($request);
        } else {
            $response = $call($request, ...$args);
        }
    } catch (\Throwable $e) {
        return static::exceptionResponse($e, $request);
    }
    if (\is_scalar($response) || null === $response) {
        $response = new Response(200, [], $response);
    }
    return $response;
});
```

触发场景 /index/index 请求
```php
// 使用一个 Base 控制器 hook beforeAction/afterAction 时发现其中的数据在业务控制器中没拿到
<?php

namespace app\middleware;

use support\bootstrap\Container;
use Webman\MiddlewareInterface;
use Webman\Http\Response;
use Webman\Http\Request;

class ActionHook implements MiddlewareInterface
{
    public function process(Request $request, callable $next): Response
    {
        if ($request->controller) {
            $action = $request->action;
            // 禁止直接访问 beforeAction afterAction
            if ($request->action === 'beforeAction' || $request->action === 'afterAction') {
                return response('<h1>404 Not Found</h1>', 404);
            }
            $controller = Container::get($request->controller);//这里的Controller已经通过get_class转为了 "app\controller\Index"
            if (method_exists($controller, 'beforeAction')) {
                $beforeResponse = call_user_func([$controller, 'beforeAction'], $request);
                if ($beforeResponse instanceof Response) {
                    return $beforeResponse;
                }
            }
            // $next 中的 controller 实例还是根据  "app\controller\index" 获得的
            $response = $next($request);

            if (method_exists($controller, 'afterAction')) {
                $afterResponse = call_user_func([$controller, 'afterAction'], $request, $response);
                if ($afterResponse instanceof Response) {
                    return $afterResponse;
                }
            }
            return $response;
        }
        return $next($request);
    }
}
```