### PR TITLE
for predis open the config item

### DIFF
--- a/src/support/Redis.php
+++ b/src/support/Redis.php
@@ -209,13 +209,39 @@ class Redis
     protected static $_instance = null;
 
     /**
+     * need to install phpredis extension
+     */
+    const PHPREDIS_CLIENT = 'phpredis';
+
+    /**
+     * need to install the 'predis/predis' packgage.
+     * cmd: composer install predis/predis
+     * c
+     */
+    const PREDIS_CLIENT = 'predis';
+
+    /**
+     * Support client collection
+     */
+    static $_allowClient = [
+        self::PHPREDIS_CLIENT,
+        self::PREDIS_CLIENT
+    ];
+
+    /**
      * @return RedisManager
      */
     public static function instance()
     {
         if (!static::$_instance) {
             $config = config('redis');
-            static::$_instance = new RedisManager('', 'phpredis', $config);
+            $client = $config['client'] ?? self::PHPREDIS_CLIENT;
+
+            if (!in_array($client, static::$_allowClient)) {
+                $client = self::PHPREDIS_CLIENT;
+            }
+
+            static::$_instance = new RedisManager('', $client, $config);
         }
         return static::$_instance;
     }


### PR DESCRIPTION
当我打算在webman中使用redis得时候，我发现需要去安装php相关得redis扩展。虽然这样的使用方式性能更高。
但是对于使用量少的开发者来说，希望能够使用更简单的配置方式。比如像开源包`predis/predis`. 所以这里提了这个pr。
目的是希望在源头得到predis的支持，而不用每次在项目中重写。为此在这个pr中开放了predis的口子。

这里开放了以后，需要在webman的redis配置文件加上以下内容:

```php

return [
    /**
     * Option support 'predis' or 'phpredis'.
     * If need to use the phpredis.  Download and install phpredis extension
     * Or composer require the 'predis/predis' package
     * Default use 'predis'
     */
    'client' => 'phpredis',
    //...此处其它配置省略
]

```

望老大审批