### PR TITLE
Update App.php

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -23,7 +23,7 @@ use Webman\Exception\ExceptionHandlerInterface;
 use Webman\Exception\ExceptionHandler;
 use Webman\Config;
 use FastRoute\Dispatcher;
-use Psr\Container\ContainerInterface;
+use Webman\Container;
 use Monolog\Logger;
 
 /**
@@ -54,7 +54,7 @@ class App
     protected static $_worker = null;
 
     /**
-     * @var ContainerInterface
+     * @var Container
      */
     protected static $_container = null;
 
@@ -280,7 +280,7 @@ class App
     }
 
     /**
-     * @return ContainerInterface
+     * @return Container
      */
     public static function container()
     {


### PR DESCRIPTION
212行中使用了`make`方法：
```php
$exception_handler = static::$_container->make($exception_handler_class, [
                'logger' => static::$_logger,
                'debug' => Config::get('app.debug')
            ]);
```
`ContainerInterface`里面的定义太简单了，没有`make`这个方法。

container实列可以在`config/container.php`中配置，但如果配置的实列中没有`make`方法，就会出错。