### PR TITLE
 查找控制器时优先从`app\\$app\\controller`里面找

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -441,8 +441,8 @@ class App
             return false;
         }
 
-        $explode[1] = $explode[1] ?? 'index';
-        $explode[2] = $explode[2] ?? 'index';
+        $explode[1] = isset($explode[1]) && !empty($explode[1]) ? $explode[1]: 'index';
+        $explode[2] = isset($explode[2]) && !empty($explode[2]) ? $explode[2]: 'index';
 
         $controller = $explode[1];
         $action = $explode[2];

--- a/src/App.php
+++ b/src/App.php
@@ -434,32 +434,32 @@ class App
             $path = \substr($path, 1);
         }
         $explode = \explode('/', $path);
-        $action = 'index';
 
-        $controller = $explode[0];
-        if ($controller === '') {
+        $app = $explode[0];
+
+        if ($app === '') {
             return false;
         }
-        if (!empty($explode[1])) {
-            $action = $explode[1];
+
+        $explode[1] = $explode[1] ?? 'index';
+        $explode[2] = $explode[2] ?? 'index';
+
+        $controller = $explode[1];
+        $action = $explode[2];
+
+        $controller_class = "app\\$app\\controller\\$controller$suffix";
+        if ($controller_action = static::getControllerAction($controller_class, $action)) {
+            return $controller_action;
         }
+
+        $controller = $explode[0];
+        $action = $explode[1];
+
         $controller_class = "app\\controller\\$controller$suffix";
         if ($controller_action = static::getControllerAction($controller_class, $action)) {
             return $controller_action;
         }
 
-        $app = $explode[0];
-        $controller = $action = 'index';
-        if (!empty($explode[1])) {
-            $controller = $explode[1];
-            if (!empty($explode[2])) {
-                $action = $explode[2];
-            }
-        }
-        $controller_class = "app\\$app\\controller\\$controller$suffix";
-        if ($controller_action = static::getControllerAction($controller_class, $action)) {
-            return $controller_action;
-        }
         return false;
     }
 

--- a/src/App.php
+++ b/src/App.php
@@ -441,8 +441,8 @@ class App
             return false;
         }
 
-        $explode[1] = isset($explode[1]) && !empty($explode[1]) ? $explode[1]: 'index';
-        $explode[2] = isset($explode[2]) && !empty($explode[2]) ? $explode[2]: 'index';
+        $explode[1] = !empty($explode[1]) ? $explode[1]: 'index';
+        $explode[2] = !empty($explode[2]) ? $explode[2]: 'index';
 
         $controller = $explode[1];
         $action = $explode[2];


### PR DESCRIPTION
当控制器`app\controller\index`中有方法`index`时，如果再新建模块`index`。
那么`index`模块里面的所有控制器都无效。

比如：访问：`http://localhost:8787/index/index/test`，
会优先匹配：`app\controller\index@index`
其实是想匹配：`app\index\controller\index@test`