### PR TITLE
Update App.php

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -513,14 +513,13 @@ class App
      */
     protected static function getAppByController($controller_calss)
     {
-        if ($controller_calss[0] === '\\') {
-            $controller_calss = \substr($controller_calss, 1);
+        $explode = \explode('\\', strtolower($controller_calss));
+        foreach ($explode as $index => $path) {
+            if ($path == 'controller') {
+                return $explode[$index - 1] ?? '';
+            }
         }
-        $tmp = \explode('\\', $controller_calss, 3);
-        if (!isset($tmp[1])) {
-            return '';
-        }
-        return strtolower($tmp[1]) === 'controller' ? '' : $tmp[1];
+        return '';
     }
 
     /**


### PR DESCRIPTION
从$controller_calss中获取app名时提取`controller`前面的路径为app名。

---
原写法对控制器的命名规则限制较大。当$controller_calsss是在vender中时，一般都会有个自己的命名空间在最前面。

`Route::any('/admin/test/index', packgexxx\admin\controller\Test::class);`

`Route::any('/admin/test2/index', packgexxx\yyyy\admin\controller\Test2::class);`

感觉从$controller_calss里面获取当前app不靠谱，如果类的命名空间不按套路的话。

`Route::any('/admin/test3/index', packgexxx\Test3::class);`

还是像`parseControllerAction`里面那样，根据当前请求路径判断好一些。