### PR TITLE
修复 uWSGI 目录穿越 (CVE-2018-7490)漏洞

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -176,7 +176,7 @@ class App
      */
     protected static function unsafeUri($connection, $path, $request)
     {
-        if (strpos($path, '/../') !== false || strpos($path,"\\") !== false || strpos($path, "\0") !== false || strpos($path, '%2f') !== false) {
+        if (strpos($path, '/../') !== false || strpos($path, '..%2f') !== false || strpos($path,"\\") !== false || strpos($path, "\0") !== false) {
             $callback = static::getFallback();
             $request->app = $request->controller = $request->action = '';
             static::send($connection, $callback($request), $request);

--- a/src/App.php
+++ b/src/App.php
@@ -176,7 +176,7 @@ class App
      */
     protected static function unsafeUri($connection, $path, $request)
     {
-        if (strpos($path, '/../') !== false || strpos($path,"\\") !== false || strpos($path, "\0") !== false) {
+        if (strpos($path, '/../') !== false || strpos($path,"\\") !== false || strpos($path, "\0") !== false || strpos($path, '%2f') !== false) {
             $callback = static::getFallback();
             $request->app = $request->controller = $request->action = '';
             static::send($connection, $callback($request), $request);
@@ -357,7 +357,7 @@ class App
      */
     protected static function findFile($connection, $path, $key, $request)
     {
-        if (!strstr($path, '%2f') && preg_match('/%[0-9a-f]{2}/i', $path)) $path = urldecode($path);
+        if (preg_match('/%[0-9a-f]{2}/i', $path)) $path = urldecode($path);
         
         $public_dir = static::$_publicPath;
         $file = "$public_dir/$path";

--- a/src/App.php
+++ b/src/App.php
@@ -357,7 +357,7 @@ class App
      */
     protected static function findFile($connection, $path, $key, $request)
     {
-        if (preg_match('/%[0-9a-f]{2}/i', $path)) $path = urldecode($path);
+        if (!strstr($path, '%2f') && preg_match('/%[0-9a-f]{2}/i', $path)) $path = urldecode($path);
         
         $public_dir = static::$_publicPath;
         $file = "$public_dir/$path";


### PR DESCRIPTION
uWSGI 2.0.17之前的PHP插件没有正确的处理DOCUMENT_ROOT检测，导致用户可以通过..%2f来跨域目录
http://127.0.0.1:8787/..%2f..%2f..%2f..%2f..%2fetc/passwd