### PR TITLE
Update $handler to $next

### DIFF
--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -26,5 +26,5 @@ interface MiddlewareInterface
      * If unable to produce the response itself, it may delegate to the provided
      * request handler to do so.
      */
-    public function process(Request $request, callable $handler): Response;
+    public function process(Request $request, callable $next): Response;
 }


### PR DESCRIPTION
个人感觉 $next 比 $handler 更合适一些，这样也可以与 webman/console 生成的变量名保持一致。