### PR TITLE
BusinessException自定义返回Response

### DIFF
--- a/src/support/exception/BusinessException.php
+++ b/src/support/exception/BusinessException.php
@@ -26,6 +26,12 @@ class BusinessException extends Exception
 {
     public function render(Request $request): ?Response
     {
-        return null;
+        if ($request->expectsJson()) {
+            $code = $this->getCode();
+            $json = ['code' => $code ? $code : 500, 'msg' => $this->getMessage()];
+            return new Response(200, ['Content-Type' => 'application/json'],
+                \json_encode($json, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+        return new Response(200, [], $this->getMessage());
     }
 }

--- a/src/support/exception/BusinessException.php
+++ b/src/support/exception/BusinessException.php
@@ -26,12 +26,6 @@ class BusinessException extends Exception
 {
     public function render(Request $request): ?Response
     {
-        $code = $this->getCode();
-        if ($request->expectsJson()) {
-            $json = ['code' => $code ? $code : 500, 'msg' => $this->getMessage()];
-            return new Response(200, ['Content-Type' => 'application/json'],
-                \json_encode($json, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        }
-        return new Response(200, [], $this->getMessage());
+        return null;
     }
 }

--- a/src/support/exception/BusinessException.php
+++ b/src/support/exception/BusinessException.php
@@ -15,6 +15,8 @@
 namespace support\exception;
 
 use Exception;
+use Webman\Http\Response;
+use Webman\Http\Request;
 
 /**
  * Class BusinessException
@@ -22,5 +24,14 @@ use Exception;
  */
 class BusinessException extends Exception
 {
-
+    public function render(Request $request): ?Response
+    {
+        $code = $this->getCode();
+        if ($request->expectsJson()) {
+            $json = ['code' => $code ? $code : 500, 'msg' => $this->getMessage()];
+            return new Response(200, ['Content-Type' => 'application/json'],
+                \json_encode($json, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+        return new Response(200, [], $this->getMessage());
+    }
 }

--- a/src/support/exception/Handler.php
+++ b/src/support/exception/Handler.php
@@ -36,6 +36,11 @@ class Handler extends ExceptionHandler
 
     public function render(Request $request, Throwable $exception): Response
     {
+        if(($exception instanceof BusinessException) && ($response = $exception->render($request)))
+        {
+            return $response;
+        }
+
         return parent::render($request, $exception);
     }
 


### PR DESCRIPTION
控制器不重用后，控制器的`__construct()`方法里面的错误无法被中间件捕获到，不怎么方便。
`BusinessException`不属于程序错误，应该方便用户直接返回一个业务方面的提示信息。
用户也可在不自定义ExceptionHandler的情况下，以继承BusinessException实现其他业务方面的功能。
在程序的任何地方抛出错误，简单粗暴。
```php
    throw new \support\exception\BusinessException('无权限操作', 403);
```