### PR TITLE
Container的make方法加个参数，是否保留最后一次实列

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -257,7 +257,7 @@ class App
         if (\is_array($call) && \is_string($call[0])) {
             if (!$controller_reuse) {
                 $call = function ($request, ...$args) use ($call, $plugin) {
-                    $call[0] = static::container($plugin)->make($call[0]);
+                    $call[0] = static::container($plugin)->make($call[0], [], true);
                     return $call($request, ...$args);
                 };
             } else {

--- a/src/Container.php
+++ b/src/Container.php
@@ -53,7 +53,9 @@ class Container implements ContainerInterface
         if (!\class_exists($name)) {
             throw new NotFoundException("Class '$name' not found");
         }
-        return new $name(... array_values($constructor));
+        $instance = new $name(... array_values($constructor));
+        $this->_instances[$name] = $instance;
+        return $instance;
     }
 
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -48,7 +48,7 @@ class Container implements ContainerInterface
      * @return mixed
      * @throws NotFoundException
      */
-    public function make(string $name, array $constructor = [], $saveInstance = false)
+    public function make(string $name, array $constructor = [], bool $saveInstance = false)
     {
         if (!\class_exists($name)) {
             throw new NotFoundException("Class '$name' not found");

--- a/src/Container.php
+++ b/src/Container.php
@@ -48,13 +48,15 @@ class Container implements ContainerInterface
      * @return mixed
      * @throws NotFoundException
      */
-    public function make(string $name, array $constructor = [])
+    public function make(string $name, array $constructor = [], $saveInstance = false)
     {
         if (!\class_exists($name)) {
             throw new NotFoundException("Class '$name' not found");
         }
-        $instance = new $name(... array_values($constructor));
-        $this->_instances[$name] = $instance;
+        $instance = new $name(...array_values($constructor));
+        if ($saveInstance) {
+            $this->_instances[$name] = $instance;
+        }
         return $instance;
     }
 


### PR DESCRIPTION
在控制器不复用的时候，控制器是通过Container的make方法，未保留实列，如果其他地方想要调用Container的get拿不到，而是新实列化的。
Container的make方法加个参数，对于某些特殊对象，可以自行决定是否保留最后一次实列。
`public function make(string $name, array $constructor = [], bool $saveInstance = false)`

```php
if ($request->controller) {
        if (Container::has($request->controller)) {
            $instance = Container::get($request->controller);
        }
}
```