### PR TITLE
Helper function upgrade

### DIFF
--- a/src/support/App.php
+++ b/src/support/App.php
@@ -19,11 +19,11 @@ class App
         ini_set('display_errors', 'on');
         error_reporting(E_ALL);
 
-        if (class_exists(Dotenv::class) && file_exists(base_path() . '/.env')) {
+        if (class_exists(Dotenv::class) && file_exists(run_path('.env'))) {
             if (method_exists(Dotenv::class, 'createUnsafeImmutable')) {
-                Dotenv::createUnsafeImmutable(base_path())->load();
+                Dotenv::createUnsafeImmutable(run_path())->load();
             } else {
-                Dotenv::createMutable(base_path())->load();
+                Dotenv::createMutable(run_path())->load();
             }
         }
 

--- a/src/support/helpers.php
+++ b/src/support/helpers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of webman.
  *
@@ -12,10 +13,10 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use support\Container;
 use support\Request;
 use support\Response;
 use support\Translation;
-use support\Container;
 use support\view\Raw;
 use support\view\Blade;
 use support\view\ThinkPHP;
@@ -25,68 +26,95 @@ use Webman\App;
 use Webman\Config;
 use Webman\Route;
 
-// Phar support.
-if (\is_phar()) {
-    \define('BASE_PATH', dirname(__DIR__));
-} else {
-    \define('BASE_PATH', realpath(__DIR__ . '/../'));
-}
-\define('WEBMAN_VERSION', '1.4');
+// Webman version
+define('WEBMAN_VERSION', '1.4');
+
+// Project base path
+define('BASE_PATH', dirname(__DIR__));
 
 /**
- * @param $return_phar
+ * Generate paths based on given information
+ * @param string $front
+ * @param string $back
+ * @return string
+ */
+function path_combine(string $front, string $back)
+{
+    return $front . ($back ? (DIRECTORY_SEPARATOR . ltrim($back, DIRECTORY_SEPARATOR)) : $back);
+}
+
+/**
+ * return the program execute directory
+ * @param string $path
+ * @return string
+ */
+function run_path(string $path = '')
+{
+    static $run_path = '';
+    if (!$run_path) {
+        $run_path = \is_phar() ? \dirname(\Phar::running(false)) : BASE_PATH;
+    }
+    return \path_combine($run_path, $path);
+}
+
+/**
+ * if the param $path equal false,will return this program current execute directory
+ * @param string|false $path
  * @return false|string
  */
-function base_path(bool $return_phar = true)
+function base_path($path = '')
 {
-    static $real_path = '';
-    if (!$real_path) {
-        $real_path = \is_phar() ? \dirname(Phar::running(false)) : BASE_PATH;
+    if (false === $path) {
+        return \run_path();
     }
-    return $return_phar ? BASE_PATH : $real_path;
+
+    return \path_combine(BASE_PATH, $path);
 }
 
 /**
+ * @param string $path
  * @return string
  */
-function app_path()
+function app_path(string $path = '')
 {
-    return BASE_PATH . DIRECTORY_SEPARATOR . 'app';
+    return \path_combine(BASE_PATH . DIRECTORY_SEPARATOR . 'app', $path);
 }
 
 /**
+ * @param string $path
  * @return string
  */
-function public_path()
+function public_path(string $path = '')
 {
-    static $path = '';
-    if (!$path) {
-        $path = \config('app.public_path', BASE_PATH . DIRECTORY_SEPARATOR . 'public');
+    static $public_path = '';
+    if (!$public_path) {
+        $public_path = \config('app.public_path') ? : \run_path('public');
     }
-    return $path;
+    return \path_combine($public_path, $path);
 }
 
 /**
+ * @param string $path
  * @return string
  */
-function config_path()
+function config_path(string $path = '')
 {
-    return BASE_PATH . DIRECTORY_SEPARATOR . 'config';
+    return \path_combine(BASE_PATH . DIRECTORY_SEPARATOR . 'config', $path);
 }
 
 /**
  * Phar support.
  * Compatible with the 'realpath' function in the phar file.
- *
+ * @param string $path
  * @return string
  */
-function runtime_path()
+function runtime_path(string $path = '')
 {
-    static $path = '';
-    if (!$path) {
-        $path = \config('app.runtime_path', BASE_PATH . DIRECTORY_SEPARATOR . 'runtime');
+    static $runtime_path = '';
+    if (!$runtime_path) {
+        $runtime_path = \config('app.runtime_path') ? : \run_path('runtime');
     }
-    return $path;
+    return \path_combine($runtime_path, $path);
 }
 
 /**
@@ -433,7 +461,6 @@ function worker_start($process_name, $config)
             $instance = Container::make($config['handler'], $config['constructor'] ?? []);
             \worker_bind($worker, $instance);
         }
-
     };
 }
 


### PR DESCRIPTION
1. 新增助手函数 run_path , 返回当前程序运行目录 **(支持phar)**
``` php
/**
 * return the program execute directory
 * @param string $path
 * @return string
 */
function run_path(string $path = '')
{
    static $run_path = '';
    if (!$run_path) {
        $run_path = \is_phar() ? \dirname(\Phar::running(false)) : BASE_PATH;
    }
    return \path_combine($run_path, $path);
}
```
2. 路径相关函数支持传入后续路径，不影响原有代码，具体如下
``` php
# base_path 接参微调
# 原 base_path(bool $return_phar = true)
# 现 base_path(string|false $path = '')

# app_path(string $path = '')
# public_path(string $path = '')
# config_path(string $path = '')
# runtime_path(string $path = '')
```