### PR TITLE
middleware 配置增强

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -263,7 +263,16 @@ class App
         $middlewares = \array_merge($middlewares, Middleware::getMiddleware($plugin, $app, $with_global_middleware));
 
         foreach ($middlewares as $key => $item) {
-            $middlewares[$key][0] = static::container($plugin)->get($item[0]);
+            $middleware = $item[0];
+            if (is_string($middleware)) {
+                $middleware = static::container($plugin)->get($middleware);
+            } elseif ($middleware instanceof \Closure) {
+                $middleware = call_user_func($middleware, static::container($plugin));
+            }
+            if (!$middleware instanceof MiddlewareInterface) {
+                throw new \InvalidArgumentException('Not support middleware type');
+            }
+            $middlewares[$key][0] = $middleware;
         }
 
         $need_inject = static::isNeedInject($call, $args);

--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -96,7 +96,7 @@ class Route
         if ($middleware === null) {
             return $this->_middlewares;
         }
-        $this->_middlewares = \array_merge($this->_middlewares, (array)$middleware);
+        $this->_middlewares = \array_merge($this->_middlewares, is_array($middleware) ? $middleware : [$middleware]);
         return $this;
     }
 


### PR DESCRIPTION
提供 middleware 的多种注入形式

使用举例：

middleware

```php
<?php
namespace app\middleware;

use Webman\MiddlewareInterface;
use Webman\Http\Response;
use Webman\Http\Request;

class Test implements MiddlewareInterface
{
    protected string $name = 'default';

    public function __construct($name = null)
    {
        if ($name) {
            $this->name = $name;
        }
    }

    public function process(Request $request, callable $next) : Response
    {
        var_dump($this->name);
        return $next($request);
    }

}
```

route

```php
Route::get('/a', fn() => 'Hello A')->middleware(\app\middleware\Test::class); // dump default
Route::get('/b', fn() => 'Hello B')->middleware(new \app\middleware\Test('B')); // dump B
Route::get('/c', fn() => 'Hello C')->middleware(fn() => new \app\middleware\Test('C')); // dump C
```