### PR TITLE
修正中间件抛出异常，无法被父级中间件获取

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -305,7 +305,11 @@ class App
         if ($middlewares) {
             $callback = \array_reduce($middlewares, function ($carry, $pipe) {
                 return function ($request) use ($carry, $pipe) {
-                    return $pipe($request, $carry);
+                    try {
+                        return $pipe($request, $carry);
+                    } catch (Throwable $e) {
+                        return static::exceptionResponse($e, $request);
+                    }
                 };
             }, function ($request) use ($call, $args) {
                 try {
@@ -792,5 +796,4 @@ class App
     {
         return Config::get($plugin ? "plugin.$plugin.$key" : $key, $default);
     }
-
 }


### PR DESCRIPTION
修正中间件抛出异常，无法被父级中间件获取，而是会结束洋葱模型，被 onMessage 捕获