### PR TITLE
Fix

### DIFF
--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -124,9 +124,9 @@ class Route
 
     /**
      * GetCallback.
-     * @return callable
+     * @return callable|null
      */
-    public function getCallback(): ?callable
+    public function getCallback()//:?callable fix: null|callable|array
     {
         return $this->callback;
     }


### PR DESCRIPTION
Fix Webman\Route\Route::getCallback(): Return value must be of type ?callable, array returned

```php
Route::get('/index', [IndexController::class, 'index']);
```

```php
declare (strict_types=1);

namespace app\controller\admin;

use support\Request;
use Throwable;

class IndexController
{
    public function index(Request $request)
    {
        try {
            $ref = new \ReflectionObject($request->route);
            $callback = $ref->getProperty('callback');
            $callback->setAccessible(true);
            $callback = $callback->getValue($request->route);

            var_dump($callback);
            var_dump(is_callable($callback));

            var_dump($request->route->getCallback());
        } catch (Throwable $e) {
            var_dump($e->getMessage());
        }

        return __METHOD__;
    }
}
```

```
array(2) {
  [0]=>
  string(36) "app\controller\admin\IndexController"
  [1]=>
  string(5) "index"
}
bool(true)
string(89) "Webman\Route\Route::getCallback(): Return value must be of type ?callable, array returned"
```