### PR TITLE
增加对框架路由对长轮询响应的支持

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -146,18 +146,16 @@ class App
                 static::send($connection, $response, $request);
                 return null;
             }
-            $routeRes = static::findRoute($connection, $path, $key, $request);
             if (
                 static::unsafeUri($connection, $path, $request) ||
                 static::findFile($connection, $path, $key, $request) ||
-                $routeRes !== false
+                ($routeRes = static::findRoute($connection, $path, $key, $request)) !== false
             ) {
-                if ($routeRes === null) {
+                if (isset($routeRes) and $routeRes === null) {
                     return;
                 }
                 return null;
             }
-
             $controllerAndAction = static::parseControllerAction($path);
             $plugin = $controllerAndAction['plugin'] ?? static::getPluginByPath($path);
             if (!$controllerAndAction || Route::hasDisableDefaultRoute($plugin)) {

--- a/src/support/LongPollingResponse.php
+++ b/src/support/LongPollingResponse.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    chaz6chez<chaz6chez1993@outlook.com>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace support;
+
+use Workerman\Timer;
+
+/**
+ * Class LongPollingResponse
+ * @package support
+ */
+class LongPollingResponse extends Response
+{
+    /** @var float 等待时长 */
+    protected $_wait;
+    /** @var Request 长轮询请求对象 */
+    protected $_request;
+    /** @var int 长轮询定时器计数 */
+    protected static $_count = 0;
+
+    /**
+     * @param Request $request
+     * @param int $status
+     * @param array $headers
+     * @param string $body
+     * @param float $wait 等待时长
+     */
+    public function __construct(Request $request, $status = 200, $headers = [], string $body = '', float $wait = 0)
+    {
+        $this->_wait = $wait;
+        $this->_request = $request;
+        parent::__construct($status, $headers, $body);
+
+        if ($this->_wait > 0) {
+            Timer::add($wait, function () {
+                self::$_count ++;
+                \Webman\App::send($this->_request->connection, $this, $this->_request);
+                self::$_count --;
+            }, [], false);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public static function getLongPollingCount(): int
+    {
+        return self::$_count;
+    }
+}

--- a/src/support/LongPollingResponse.php
+++ b/src/support/LongPollingResponse.php
@@ -42,12 +42,20 @@ class LongPollingResponse extends Response
         parent::__construct($status, $headers, $body);
 
         if ($this->_wait > 0) {
+            self::$_count ++;
             Timer::add($wait, function () {
-                self::$_count ++;
-                \Webman\App::send($this->_request->connection, $this, $this->_request);
-                self::$_count --;
+                $this->send();
             }, [], false);
         }
+    }
+
+    /**
+     * @return void
+     */
+    public function send()
+    {
+        \Webman\App::send($this->_request->connection, $this, $this->_request);
+        self::$_count --;
     }
 
     /**


### PR DESCRIPTION
## 原理

1. 使用workerman自带的Timer对长轮询请求进行处理
2. onMessage忽略来自LongPollingResponse的send处理

## 描述

1. 增加了LongPollingResponse
    - LongPollingResponse接收request对象参数及wait参数
    - wait参数用于控制长轮询等待时长
3. 修改了App.php onMessage、send部分

## 使用

1. 控制器返回LongPollingResponse对象即可
```
    public function test(Request $request): Response
    {
        return (new LongPollingResponse($request,200, [], '{"info": "this is long polling response. "}',  20));
    }
```

## 优化

目前只是一个demo，实现简单的长轮询响应，后期可以对其功能性进行增加和优化；
可以对长轮询响应数量上限做限制或者超时时间做处理，当超过阈值时自动退化为正常请求响应；
