### PR TITLE
Check if the `CursorPaginator::class` exists

### DIFF
--- a/src/support/bootstrap/LaravelDb.php
+++ b/src/support/bootstrap/LaravelDb.php
@@ -113,9 +113,11 @@ class LaravelDb implements Bootstrap
                 $page = (int)($request->input($pageName, 1));
                 return $page > 0 ? $page : 1;
             });
-            CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') {
-                return Cursor::fromEncoded(request()->input($cursorName));
-            });
+            if (class_exists(CursorPaginator::class)) {
+                CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') {
+                    return Cursor::fromEncoded(request()->input($cursorName));
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
#89 引入的游标分页设置在 [illuminate/pagination #v8.41.0](https://github.com/illuminate/pagination/tree/v8.41.0) 版本才支持，此版本要求 PHP "^7.3|^8.0"
webman 最低要求 PHP 版本为 7.2，无法安装此版本，不兼容此设置

https://www.workerman.net/q/11852

