### PR TITLE
View assigned variables may stay shared between requests

### DIFF
--- a/src/support/view/Blade.php
+++ b/src/support/view/Blade.php
@@ -32,18 +32,14 @@ use function runtime_path;
 class Blade implements View
 {
     /**
-     * @var array
-     */
-    protected static $vars = [];
-
-    /**
      * Assign.
      * @param string|array $name
      * @param mixed $value
      */
     public static function assign($name, $value = null)
     {
-        static::$vars = array_merge(static::$vars, is_array($name) ? $name : [$name => $value]);
+        $request = request();
+        $request->_view_vars = array_merge((array) $request->_view_vars, is_array($name) ? $name : [$name => $value]);
     }
 
     /**
@@ -71,9 +67,7 @@ class Blade implements View
                 $extension($views[$key]);
             }
         }
-        $vars = array_merge(static::$vars, $vars);
-        $content = $views[$key]->render($template, $vars);
-        static::$vars = [];
-        return $content;
+        $vars = array_merge((array) $request->_view_vars, $vars);
+        return $views[$key]->render($template, $vars);
     }
 }

--- a/src/support/view/Raw.php
+++ b/src/support/view/Raw.php
@@ -34,18 +34,14 @@ use function request;
 class Raw implements View
 {
     /**
-     * @var array
-     */
-    protected static $vars = [];
-
-    /**
      * Assign.
      * @param string|array $name
      * @param mixed $value
      */
     public static function assign($name, $value = null)
     {
-        static::$vars = array_merge(static::$vars, is_array($name) ? $name : [$name => $value]);
+        $request = request();
+        $request->_view_vars = array_merge((array) $request->_view_vars, is_array($name) ? $name : [$name => $value]);
     }
 
     /**
@@ -66,19 +62,17 @@ class Raw implements View
         $baseViewPath = $plugin ? base_path() . "/plugin/$plugin/app" : app_path();
         $__template_path__ = $app === '' ? "$baseViewPath/view/$template.$viewSuffix" : "$baseViewPath/$app/view/$template.$viewSuffix";
 
-        extract(static::$vars);
+        extract((array) $request->_view_vars);
         extract($vars);
         ob_start();
         // Try to include php file.
         try {
             include $__template_path__;
         } catch (Throwable $e) {
-            static::$vars = [];
             ob_end_clean();
             throw $e;
         }
-        static::$vars = [];
+
         return ob_get_clean();
     }
-
 }

--- a/src/support/view/ThinkPHP.php
+++ b/src/support/view/ThinkPHP.php
@@ -33,18 +33,14 @@ use function runtime_path;
 class ThinkPHP implements View
 {
     /**
-     * @var array
-     */
-    protected static $vars = [];
-
-    /**
      * Assign.
      * @param string|array $name
      * @param mixed $value
      */
     public static function assign($name, $value = null)
     {
-        static::$vars = array_merge(static::$vars, is_array($name) ? $name : [$name => $value]);
+        $request = request();
+        $request->_view_vars = array_merge((array) $request->_view_vars, is_array($name) ? $name : [$name => $value]);
     }
 
     /**
@@ -72,10 +68,8 @@ class ThinkPHP implements View
         $options = array_merge($defaultOptions, config("{$configPrefix}view.options", []));
         $views = new Template($options);
         ob_start();
-        $vars = array_merge(static::$vars, $vars);
+        $vars = array_merge((array) $request->_view_vars, $vars);
         $views->fetch($template, $vars);
-        $content = ob_get_clean();
-        static::$vars = [];
-        return $content;
+        return ob_get_clean();
     }
 }

--- a/src/support/view/Twig.php
+++ b/src/support/view/Twig.php
@@ -34,18 +34,14 @@ use function request;
 class Twig implements View
 {
     /**
-     * @var array
-     */
-    protected static $vars = [];
-
-    /**
      * Assign.
      * @param string|array $name
      * @param mixed $value
      */
     public static function assign($name, $value = null)
     {
-        static::$vars = array_merge(static::$vars, is_array($name) ? $name : [$name => $value]);
+        $request = request();
+        $request->_view_vars = array_merge((array) $request->_view_vars, is_array($name) ? $name : [$name => $value]);
     }
 
     /**
@@ -74,9 +70,7 @@ class Twig implements View
                 $extension($views[$key]);
             }
         }
-        $vars = array_merge(static::$vars, $vars);
-        $content = $views[$key]->render("$template.$viewSuffix", $vars);
-        static::$vars = [];
-        return $content;
+        $vars = array_merge((array) $request->_view_vars, $vars);
+        return $views[$key]->render("$template.$viewSuffix", $vars);
     }
 }


### PR DESCRIPTION
Here is an example:

```php
<?php

namespace app\controller;

use support\Request;
use support\Response;
use support\View;

class SomeController
{
	public function index(Request $request): Response
	{
		View::assign('username', 'Peter');

               // some logic which throws an exception
		throw new \Exception('some exception');

		// view variable $username still alive and available in next requests
		return view('index');
	}
}
`