### PR TITLE
增加功能: Config::get()方法中,如果没有指定配置文件名称,则默认获取config/app.php中的值

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -226,6 +226,9 @@ class Config
         if ($key === null) {
             return static::$config;
         }
+        if (strpos($key,'.') === false) {
+            $key = 'app.' . $key;
+        }
         $keyArray = explode('.', $key);
         $value = static::$config;
         $found = true;


### PR DESCRIPTION
增加功能: Config::get()方法中,如果没有指定配置文件名称,则默认获取config/app.php中的值