### PR TITLE
优化获取客户端IP地址的方法

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -216,9 +216,12 @@ class Request extends \Workerman\Protocols\Http\Request
         if ($safeMode && !static::isIntranetIp($remoteIp)) {
             return $remoteIp;
         }
-        $ip = $this->header('x-real-ip', $this->header('x-forwarded-for',
-            $this->header('client-ip', $this->header('x-client-ip',
-                $this->header('via', $remoteIp)))));
+        $ip = $this->header('x-forwarded-for')
+           ?? $this->header('x-real-ip')
+           ?? $this->header('client-ip')
+           ?? $this->header('x-client-ip')
+           ?? $this->header('via')
+           ?? $remoteIp;
         if (is_string($ip)) {
             $ip = current(explode(',', $ip));
         }


### PR DESCRIPTION
使用更简洁的空合并操作符来获取客户端的IP地址，替代了原有的较为冗长的函数调用。
优先使用 X-Forwarded-For 标头，这个标头至少有标准可依赖。增加获取到真实IP的概率。