### PR TITLE
解决请求未经过任何中间件时，请求返回可能不为Response问题

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -369,13 +369,20 @@ class App
                 return $response;
             });
         } else {
-            if (!$anonymousArgs) {
-                $callback = $call;
-            } else {
-                $callback = function ($request) use ($call, $anonymousArgs) {
-                    return $call($request, ...$anonymousArgs);
-                };
-            }
+            $callback = function ($request) use ($call, $anonymousArgs) {
+                if (!$anonymousArgs) {
+                    $response = $call($request);
+                } else {
+                    $response = $call($request, ...$anonymousArgs);
+                }
+                if (!$response instanceof Response) {
+                    if (!is_string($response)) {
+                        $response = static::stringify($response);
+                    }
+                    $response = new Response(200, [], $response);
+                }
+                return $response;
+            };
         }
         return $callback;
     }


### PR DESCRIPTION
在`App::send`中调用`$connection->send($response)`，
如果$response不是Response，而是一个实现了`__toString()`的对象，那么`__toString()`将被延迟到`Workerman\Protocols\Http::encode()`中调用，如果`__toString()`用到了一些wenbman里面的东西，比如使用request()，返回空。 因为是`$connection->send()`之前调用的`Context::destroy();`销毁了。