### PR TITLE
修正 Container 类型

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -27,7 +27,6 @@ use support\exception\PageNotFoundException;
 use think\Model as ThinkModel;
 use InvalidArgumentException;
 use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
 use ReflectionException;

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,7 +2,6 @@
 
 namespace Webman;
 
-use Psr\Container\ContainerInterface;
 use Webman\Exception\NotFoundException;
 use function array_key_exists;
 use function class_exists;
@@ -75,7 +74,7 @@ class Container implements ContainerInterface
      * @param array $definitions
      * @return $this
      */
-    public function addDefinitions(array $definitions): Container
+    public function addDefinitions(array $definitions): static
     {
         $this->definitions = array_merge($this->definitions, $definitions);
         return $this;

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of webman.
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the MIT-LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    walkor<walkor@workerman.net>
+ * @copyright walkor<walkor@workerman.net>
+ * @link      http://www.workerman.net/
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Webman;
+
+use Webman\Exception\NotFoundException;
+use Psr\Container\ContainerInterface as PsrInterface;
+
+interface ContainerInterface extends PsrInterface
+{
+    /**
+     * Make.
+     * @param string $name
+     * @param array $constructor
+     * @return mixed
+     * @throws NotFoundException
+     */
+    public function make(string $name, array $constructor = []);
+
+
+    /**
+     * AddDefinitions.
+     * @param array $definitions
+     * @return $this
+     */
+    public function addDefinitions(array $definitions): static;
+
+}


### PR DESCRIPTION
App.php 中使用 `Psr\Container\ContainerInterface` 接口作为 `$container` 的参数类型，
但 `$container->make()` 方法不属于 `Psr\Container\ContainerInterface` 。