### PR TITLE
修复only和except方法丢失数组中的null值

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -87,28 +87,17 @@ class Request extends \Workerman\Protocols\Http\Request
      */
     public function only(array $keys): array
     {
-        $all = $this->all();
-        $result = [];
-        foreach ($keys as $key) {
-            if (isset($all[$key])) {
-                $result[$key] = $all[$key];
-            }
-        }
-        return $result;
+        return array_filter($this->all() ?? [], fn($k) => in_array($k, $keys), ARRAY_FILTER_USE_KEY);
     }
 
     /**
      * Except
      * @param array $keys
-     * @return mixed|null
+     * @return array
      */
-    public function except(array $keys)
+    public function except(array $keys): array
     {
-        $all = $this->all();
-        foreach ($keys as $key) {
-            unset($all[$key]);
-        }
-        return $all;
+        return array_filter($this->all() ?? [], fn($k) => !in_array($k, $keys), ARRAY_FILTER_USE_KEY);
     }
 
     /**


### PR DESCRIPTION
以下示例丢失了key为e的元素
```php
$all = [
    'a' => 'a',
    'b' => true,
    'c' => false,
    'd' => '',
    'e' => null,
    'f' => 0,
    'g' => 1,
];
$keys = ['a', 'b', 'c', 'd', 'e', 'f'];
$result = [];
foreach ($keys as $key) {
    if (isset($all[$key])) {
        $result[$key] = $all[$key];
    }
}
print_r($result);
// 错误返回
//Array
//(
//    [a] => a
//    [b] => 1
//    [c] => 
//    [d] => 
//    [f] => 0
//)
```