### PR TITLE
Added null check for request object in session function

### DIFF
--- a/src/support/helpers.php
+++ b/src/support/helpers.php
@@ -373,7 +373,11 @@ if (!function_exists('session')) {
      */
     function session(array|string|null $key = null, mixed $default = null): mixed
     {
-        $session = \request()->session();
+        $request = \request();
+        if (!$request) {
+            return $default;
+        }
+        $session = $request->session();
         if (null === $key) {
             return $session;
         }
@@ -667,6 +671,6 @@ if (!function_exists('input')) {
      */
     function input(?string $param = null, mixed $default = null): mixed
     {
-        return is_null($param) ? request()->all() : request()->input($param, $default);
+        return is_null($param) ? \request()->all() : \request()->input($param, $default);
     }
 }


### PR DESCRIPTION
Session is a frequently used method, but there is no request object in some environments, which will cause errors.