### PR TITLE
fix: use SplFileInfo methods and pathname string in Config and Route …

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -205,14 +205,15 @@ class Config
         $iterator = new RecursiveIteratorIterator($dirIterator);
         foreach ($iterator as $file) {
             /** var SplFileInfo $file */
-            if (is_dir($file) || $file->getExtension() != 'php' || in_array($file->getBaseName('.php'), $excludeFile)) {
+            if ($file->isDir() || $file->getExtension() != 'php' || in_array($file->getBaseName('.php'), $excludeFile)) {
                 continue;
             }
+            $filePath = $file->getPathname();
             $appConfigFile = $file->getPath() . '/app.php';
             if (!is_file($appConfigFile)) {
                 continue;
             }
-            $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', substr($file, 0, -4));
+            $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', substr($filePath, 0, -4));
             $explode = array_reverse(explode(DIRECTORY_SEPARATOR, $relativePath));
             if (count($explode) >= 2) {
                 $appConfig = include $appConfigFile;
@@ -220,7 +221,7 @@ class Config
                     continue;
                 }
             }
-            $config = include $file;
+            $config = include $filePath;
             foreach ($explode as $section) {
                 $tmp = [];
                 $tmp[$section] = $config;

--- a/src/Route.php
+++ b/src/Route.php
@@ -588,7 +588,8 @@ class Route
                     if ($file->getBaseName('.php') !== 'route') {
                         continue;
                     }
-                    $appConfigFile = pathinfo($file, PATHINFO_DIRNAME) . '/app.php';
+                    $filePath = $file->getPathname();
+                    $appConfigFile = pathinfo($filePath, PATHINFO_DIRNAME) . '/app.php';
                     if (!is_file($appConfigFile)) {
                         continue;
                     }
@@ -596,7 +597,7 @@ class Route
                     if (empty($appConfig['enable'])) {
                         continue;
                     }
-                    require_once $file;
+                    require_once $filePath;
                 }
             }
             static::loadAnnotationRoutes();


### PR DESCRIPTION
In `Webman\Config::loadFromDir()` and `Webman\Route::load()`, files returned by `RecursiveIteratorIterator` are `SplFileInfo` instances.

- Previously, `is_dir($file)` was called on `SplFileInfo`. In PHP strict type checking, static analysis (such as PHPStan / Psalm), or ahead-of-time (AOT) compilers (e.g. TypePHP), passing an object to `is_dir(string $filename)` triggers a fatal
`TypeError: is_dir(): Argument #1 ($filename) must be of type string, SplFileInfo given`.
- `SplFileInfo` provides a native `$file->isDir()` method which directly accesses the iterator's file status without redundant `__toString()` string conversions and extra filesystem stat calls.
- Furthermore, explicit string pathnames (`$file->getPathname()`) are now passed to `substr()`, `pathinfo()`, `include`, and `require_once`.
